### PR TITLE
#20 fix pre-commit for unix-like system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **.env
 **.venv
+**venv
 **/models/*
 !/models/.gitkeep
 **__pycache__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,10 @@ repos:
         language: python
         types: [python]
         args: [--errors-only]
+      - id: add-modified-files
+        name: Add modified files by the hooks
+        entry: ./add_modified_files.sh
+        language: system
       - id: pytest
         name: Run pytest
         entry: python -m pytest  # Make sure pytest is available in the environment (venv)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,9 @@ repos:
         language: python
         types: [python]
         args: [--errors-only]
-      - id: unittest
-        name: Run unittest
-        entry: python -m unittest discover  # Make sure unittest is available in the environment (venv)
+      - id: pytest
+        name: Run pytest
+        entry: python -m pytest  # Make sure pytest is available in the environment (venv)
         language: system
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,23 @@
+# Make sure to activate the venv environment before using the pre-commit hooks
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.10.0 # Assurez-vous d'utiliser la dernière version
+    rev: 24.10.0
     hooks:
       - id: black
-        entry: .venv/Scripts/black.exe
+        entry: black  # Make sure black is available in the environment (venv)
         language_version: python3
 
   - repo: local
     hooks:
       - id: pylint
         name: pylint
-        entry: cmd /c "set PYTHONPATH=%cd%& .venv\Scripts\pylint.exe --disable=E0213"
+        entry: pylint  # Make sure pylint is available in the environment (venv)
         language: python
         types: [python]
         args: [--errors-only]
       - id: unittest
         name: Run unittest
-        entry: .venv/Scripts/python.exe -m unittest discover
+        entry: python -m unittest discover  # Make sure unittest is available in the environment (venv)
         language: system
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: isort
         name: isort
         entry: isort  # Make sure isort is available in the environment (venv)
-        language: python
+        language: system
         types: [python]
       - id: pylint
         name: pylint
@@ -22,11 +22,14 @@ repos:
         args: [--errors-only]
       - id: add-modified-files
         name: Add modified files by the hooks
-        entry: ./add_modified_files.sh
+        entry: python ./add_modified_files.py
         language: system
+        types: [python]
       - id: pytest
-        name: Run pytest
-        entry: python -m pytest  # Make sure pytest is available in the environment (venv)
+        name: pytest
+        stages: [pre-commit]
+        entry: pytest  # Make sure pytest is available in the environment (venv)
         language: system
+        types: [python]
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,11 @@ repos:
 
   - repo: local
     hooks:
+      - id: isort
+        name: isort
+        entry: isort  # Make sure isort is available in the environment (venv)
+        language: python
+        types: [python]
       - id: pylint
         name: pylint
         entry: pylint  # Make sure pylint is available in the environment (venv)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,7 @@ repos:
         types: [python]
       - id: pytest
         name: pytest
-        stages: [pre-commit]
-        entry: pytest  # Make sure pytest is available in the environment (venv)
+        entry: python -m pytest  # Make sure pytest is available in the environment (venv)
         language: system
         types: [python]
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ There are several ways to run pre-commit:
     nvidia-smi
     ```
 
+5. In Docker Desktop for windows, enable Ubuntu WSL integration `Options > Resources > WSL Integration`.
+
 ## Run tests
 
 1. Open terminal in project root

--- a/add_modified_files.py
+++ b/add_modified_files.py
@@ -1,0 +1,32 @@
+import subprocess
+
+
+def add_modified_files():
+    try:
+        # Get the list of modified files in the staging area
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--cached"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+
+        # Get the output (list of files)
+        files = result.stdout.strip().split("\n")
+
+        if not files or files == [""]:
+            print("No files to add.")
+            return
+
+        # Add the modified files back to the staging area
+        subprocess.run(["git", "add"] + files, check=True)
+        print(f"Added files to staging: {', '.join(files)}")
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error while running git command: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+
+if __name__ == "__main__":
+    add_modified_files()

--- a/add_modified_files.sh
+++ b/add_modified_files.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# This script stages only the modified files affected by pre-commit hooks
+FILES=$(git diff --name-only --cached)
+git add $FILES

--- a/add_modified_files.sh
+++ b/add_modified_files.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# This script stages only the modified files affected by pre-commit hooks
-FILES=$(git diff --name-only --cached)
-git add $FILES

--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ class PredictRequest(BaseModel):
     max_new_tokens: int = 128
 
     @field_validator("prompt")
-    def validate_prompt(cls, prompt):
+    def validate_prompt(cls, prompt):  # pylint: disable=no-self-argument
         if not prompt:
             raise ValueError("No prompt provided")
         if len(prompt) > 2048:
@@ -48,7 +48,7 @@ class ChangeModelRequest(BaseModel):
     hf_model_id: str
 
     @field_validator("hf_model_id")
-    def validate_hf_model_id(cls, hf_model_id):
+    def validate_hf_model_id(cls, hf_model_id):  # pylint: disable=no-self-argument
         if not hf_model_id:
             raise ValueError("No hf_model_id provided")
         return hf_model_id
@@ -58,7 +58,7 @@ class ChangeTokenRequest(BaseModel):
     hf_token: str
 
     @field_validator("hf_token")
-    def validate_token(cls, hf_token):
+    def validate_token(cls, hf_token):  # pylint: disable=no-self-argument
         if not hf_token:
             raise ValueError("No hf_token provided")
         return hf_token

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,9 @@
-from dotenv import load_dotenv
 import logging
 import os
 
 import requests
 import torch
+from dotenv import load_dotenv
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Description des changements

- Changement des entry pour les pre-commit (devrait fonctionner pour tout genre d'environnement si l'environnement virtuel est activé)
- Changement du pre-commit pour utilisé pytest (unittest ne roulait aucun tests)
- Ajout de pylint tagg dans `app.py` pour supprimer un warning pylint invalide avec pydantic.

## Étapes à faire avant de demander une revue

- [x] Mon code respecte les guidelines du projet.
- [x] J'ai revu mon code.
- [x] Mon code est commenté dans les sections plus complexes.
- [x] Les tests existants passent toujours.
