### PR TITLE
Feature/#5 prompting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 node_modules
 log-advice-generator
-models
+hf_local_models
 tests
 .venv
 venv

--- a/.env.exemple
+++ b/.env.exemple
@@ -4,4 +4,4 @@
 # Qwen/Qwen2.5-0.5B (Smallest, used for testing)
 HF_MODEL_ID=meta-llama/Llama-3.2-1B-Instruct
 HF_TOKEN=token
-MODEL_DIR=./models
+MODEL_DIR=./hf_local_models

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Run Integration Tests
       run: |
-        pytest
+        pytest -v
 
   lint-and-format:
     name: Formatting and Linting with Black and Pylint

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 **.env
 **.venv
-**venv
-**/models/*
-!/models/.gitkeep
+**/hf_local_models/*
+!/hf_local_models/.gitkeep
 **__pycache__
 **.pytest_cache
 **.DS_Store
 **/node_modules
 **/node_modules/
+.python_version

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 **.DS_Store
 **/node_modules
 **/node_modules/
-.python_version
+.python-version

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,13 +12,5 @@
             "console": "integratedTerminal",
             "python": "${command:python.interpreterPath}"
         },
-        {
-            "name": "Run Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}/log-advice-generator",
-            ],
-        }
     ]
 }

--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ app = FastAPI(
 
 MODEL_DIR = os.getenv("MODEL_DIR")
 if MODEL_DIR in [None, ""]:
-    MODEL_DIR = "./models"
+    MODEL_DIR = "./hf_local_models"
 os.makedirs(MODEL_DIR, exist_ok=True)
 
 model_manager = ModelManager(MODEL_DIR)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - HF_TOKEN=${HF_TOKEN}
       - HF_MODEL_ID=${HF_MODEL_ID}
     volumes:
-      - ${MODEL_DIR}:/app/models
+      - ${MODEL_DIR}:/app/hf_local_models
     deploy:
       resources:
         reservations:

--- a/models.py
+++ b/models.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel, field_validator
+
+
+class PredictRequest(BaseModel):
+    prompt: str
+    max_new_tokens: int = 128
+
+    @field_validator("prompt")
+    def validate_prompt(cls, prompt):
+        if not prompt:
+            raise ValueError("No prompt provided")
+        if len(prompt) > 2048:
+            raise ValueError("Prompt is too long")
+        return prompt
+
+
+class ChangeModelRequest(BaseModel):
+    hf_model_id: str
+
+    @field_validator("hf_model_id")
+    def validate_hf_model_id(cls, hf_model_id):
+        if not hf_model_id:
+            raise ValueError("No hf_model_id provided")
+        return hf_model_id
+
+
+class ChangeTokenRequest(BaseModel):
+    hf_token: str
+
+    @field_validator("hf_token")
+    def validate_token(cls, hf_token):
+        if not hf_token:
+            raise ValueError("No hf_token provided")
+        return hf_token

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ fastapi
 pydantic
 httpx
 python-dotenv
+bitsandbytes
+accelerate>=0.26.0

--- a/tests/escaped_code.text
+++ b/tests/escaped_code.text
@@ -1,0 +1,1 @@
+def validate_huggingface_token(hf_token: str) -> bool:\r\n    headers = {\"Authorization\": f\"Bearer {hf_token}\"}\r\n    response = requests.get(\"https:\/\/huggingface.co\/api\/whoami-v2\", headers=headers)\r\n    return response.status_code == 200

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,10 +2,12 @@ import pytest
 from dotenv import load_dotenv
 from fastapi.testclient import TestClient
 
+import app as app_file
 from app import app
 
 # Load environment variables from .env file
 load_dotenv()
+
 
 client = TestClient(app)
 
@@ -13,6 +15,18 @@ client = TestClient(app)
 def test_predict():
     response = client.post(
         "/predict", json={"prompt": "Hello, world!", "max_new_tokens": 5}
+    )
+    assert response.status_code == 200
+    assert "content" in response.json()
+
+
+def test_generate_log_advice():
+
+    with open("tests/escaped_code.text", "r") as file:
+        escaped_code = file.read()
+
+    response = client.post(
+        "/generate/log-advice", json={"prompt": escaped_code, "max_new_tokens": 10}
     )
     assert response.status_code == 200
     assert "content" in response.json()
@@ -58,3 +72,4 @@ def test_model_info():
     assert response.status_code == 200
     assert "model_name" in response.json()
     assert "device" in response.json()
+    assert "model_dir" in response.json()

--- a/utils.py
+++ b/utils.py
@@ -4,12 +4,14 @@ import os
 import requests
 import torch
 from dotenv import load_dotenv
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 
 logger = logging.getLogger(__name__)
 
 # Load environment variables from .env file
 load_dotenv()
+
+delimiter = "\n\n~~~~~"
 
 
 def validate_huggingface_token(hf_token: str) -> bool:
@@ -18,86 +20,125 @@ def validate_huggingface_token(hf_token: str) -> bool:
     return response.status_code == 200
 
 
+def generate_model_response(model, tokenizer, prompt, max_tokens, temperature=0.2):
+    inputs = tokenizer(prompt, return_tensors="pt", padding=True, truncation=True)
+    inputs["attention_mask"] = (
+        inputs["attention_mask"] if "attention_mask" in inputs else None
+    )
+
+    device = next(model.parameters()).device  # Automatically detects the model’s device
+    inputs = {key: value.to(device) for key, value in inputs.items()}
+
+    outputs = model.generate(
+        **inputs,
+        max_new_tokens=max_tokens,
+        temperature=temperature,
+        repetition_penalty=1.2,
+        do_sample=True,
+    )
+    content = tokenizer.batch_decode(outputs, skip_special_tokens=True)[0]
+    content = content.split(delimiter)[-1].strip()
+    return content
+
+
+def build_prompt(context, prompt):
+    return ("[INST]" + context + prompt + "[/INST]" + delimiter).strip()
+
+
 class ModelManager:
+
+    token: str
+    model_dir: str
+    model: AutoModelForCausalLM
+    tokenizer: AutoTokenizer
+    device: torch.device
+    model_name: str
+
     def __init__(self, model_dir: str):
         self.model_dir = model_dir
-        self.model = None
-        self.token = None
-        self.tokenizer = None
-        self.device = None
-        self.model_name = None
 
-    def create_model(self, model_name: str, hf_token: str):
-        try:
-            # Check if the model is already in the model directory, otherwise download it
-            if not os.path.exists(os.path.join(self.model_dir, model_name)):
-                tokenizer = AutoTokenizer.from_pretrained(
-                    model_name,
-                    trust_remote_code=True,
-                    cache_dir=self.model_dir,
-                    token=hf_token,
-                )
-                # Add a new [PAD] hf_token
-                tokenizer.add_special_tokens({"pad_token": "[PAD]"})
-                model = AutoModelForCausalLM.from_pretrained(
-                    model_name,
-                    trust_remote_code=True,
-                    cache_dir=self.model_dir,
-                    token=hf_token,
-                    pad_token_id=tokenizer.eos_token_id,
-                )
-            else:
-                tokenizer = AutoTokenizer.from_pretrained(
-                    self.model_dir, trust_remote_code=True, hf_token=hf_token
-                )
-                # Add a new [PAD] hf_token
-                tokenizer.add_special_tokens({"pad_token": "[PAD]"})
-                model = AutoModelForCausalLM.from_pretrained(
-                    self.model_dir,
-                    trust_remote_code=True,
-                    token=hf_token,
-                    pad_token_id=tokenizer.eos_token,
-                )
-
-            # Move model to GPU if available
-            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-            model.to(device)
-            logger.info(f"Model {model_name} loaded successfully on {device}")
-            return model, tokenizer, device
-        except Exception as e:
-            logger.error(f"Failed to create model {model_name}: {e}")
-            return None
-
-    def set_model_name(self, model_name: str):
-        response = self.create_model(model_name, self.token)
-        if response is not None:
-            self.model, self.tokenizer, self.device = response
-            self.model_name = model_name
-            logger.info(f"Model set to {model_name}")
-            return True
-        else:
-            logger.error(f"Failed to set model to {model_name}")
-            return False
-
-    def set_token(self, new_token: str):
-        validate = validate_huggingface_token(new_token)
-        response = self.create_model(self.model_name, new_token)
-        if validate and response is not None:
-            self.model, self.tokenizer, self.device = response
-            self.token = new_token
-            logger.info("Token updated successfully")
-            return True
-        else:
-            logger.error("Failed to update hf_token")
-            return False
-
-    def init_model(self):
         # Model details
         # meta-llama/Llama-3.2-1B-Instruct
         # Qwen/Qwen2.5-Coder-1.5B-Instruct
         # Qwen/Qwen2.5-0.5B
 
-        self.model_name = os.getenv("HF_MODEL_ID", "meta-llama/Llama-3.2-1B-Instruct")
-        self.token = os.getenv("HF_TOKEN")
-        self.set_model_name(self.model_name)
-        logger.info(f"Device: {self.device}")
+        model_name = os.getenv("HF_MODEL_ID", "meta-llama/Llama-3.2-1B-Instruct")
+        token = os.getenv("HF_TOKEN")
+        self.set_token(token)
+        self.set_model(model_name)
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        logger.info(
+            f"Memory allocated on GPU: {torch.cuda.memory_allocated() / 1024 ** 3:.2f} GB"
+        )
+
+    def create_model(self, model_name: str):
+        try:
+            quant_config = (
+                BitsAndBytesConfig(load_in_8bit=True)
+                if torch.cuda.is_available()
+                else None
+            )
+
+            if not self.token:
+                logger.warning(
+                    "Hugging Face token is not provided. Initializing without token."
+                )
+                tokenizer = AutoTokenizer.from_pretrained(
+                    model_name,
+                    trust_remote_code=True,
+                    cache_dir=self.model_dir,
+                )
+                model = AutoModelForCausalLM.from_pretrained(
+                    model_name,
+                    trust_remote_code=True,
+                    cache_dir=self.model_dir,
+                    pad_token_id=tokenizer.eos_token_id,
+                    quantization_config=quant_config,
+                )
+            else:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    model_name,
+                    trust_remote_code=True,
+                    cache_dir=self.model_dir,
+                    token=self.token,
+                )
+                model = AutoModelForCausalLM.from_pretrained(
+                    model_name,
+                    trust_remote_code=True,
+                    cache_dir=self.model_dir,
+                    token=self.token,
+                    pad_token_id=tokenizer.eos_token_id,
+                    quantization_config=quant_config,
+                )
+
+            # Add a new [PAD] token
+            tokenizer.add_special_tokens({"pad_token": "[PAD]"})
+
+            logger.info(f"Model {model_name} created successfully")
+
+            return model, tokenizer
+        except Exception as e:
+            logger.error(f"Failed to create model {model_name}: {e}")
+            return None
+
+    def set_model(self, model_name: str):
+        logger.info(f"Setting model to {model_name}")
+        response = self.create_model(model_name)
+        if response is not None:
+            self.model, self.tokenizer = response
+            self.model_name = model_name
+            logger.info(f"Model successfully set to {model_name}")
+            return True
+        else:
+            logger.error(f"Failed to set model to {model_name}")
+            self.model_name = None  # Fallback to None
+            return False
+
+    def set_token(self, new_token: str):
+        if validate_huggingface_token(new_token):
+            self.token = new_token
+            logger.info("Token successfully set")
+            return True
+        else:
+            logger.error("Failed to set token")
+            return False


### PR DESCRIPTION
## Description des changements

- Ajout d'un endpoint avec le prompting pour du log advice
- Migration de la tokenisation et de la génération vers utils
- Ajout de la séparation de la réponse à l'aide du delimiter après le decoding
- Changement du nom du folder avec les models
- Migration des modeles pour les requêtes dans un fichier séparer 

## Étapes à faire avant de demander une revue

- [x] Mon code respecte les guidelines du projet.
- [x] J'ai revu mon code.
- [x] Mon code est commenté dans les sections plus complexes.
- [x] Les tests existants passent toujours.

## Étape pour tester le code et essayer un prompt

Ces étapes sont nécessaires puisque les caractères spéciaux du code doivent être escaped. Ce genre de tâche sera fait automatiquement par le code dans le client-side.

1. Lancer le webapp
2. Prendre le code qui se trouve dans `tests/escaped_code.text`.
3. Mettre le code escaped le body pour la requête du endpoint `/generate/log-advice`.
4. Lancer la requête, voir le swagger au `localhost:8888/docs`

